### PR TITLE
feat: enable LAN access

### DIFF
--- a/AppleOnDeviceOpenAI/Services/VaporServerManager.swift
+++ b/AppleOnDeviceOpenAI/Services/VaporServerManager.swift
@@ -262,8 +262,7 @@ class VaporServerManager: ObservableObject {
                     for try await cumulativeResponse in responseStream {
                         print("DEBUG: Processing stream chunk")
                         // Calculate the delta (new content since last iteration)
-                        let deltaContent = String(
-                            cumulativeResponse.dropFirst(previousContent.count))
+                        let deltaContent = String(cumulativeResponse.content.dropFirst(previousContent.count))
 
                         // Skip empty deltas (except for the first chunk which might include role)
                         if deltaContent.isEmpty && !isFirstChunk {
@@ -296,7 +295,7 @@ class VaporServerManager: ObservableObject {
                         print("DEBUG: Successfully wrote SSE data chunk")
 
                         // Update tracking variables
-                        previousContent = cumulativeResponse
+                        previousContent = cumulativeResponse.content
                         isFirstChunk = false
                     }
 


### PR DESCRIPTION
This PR enables LAN access to the local Foundation Models.

- Bind to "0.0.0.0" to enable LAN access.
- Show the local (LAN) address as the serverURL.
- Retrieve the IPv4 address of en0 or en1.
